### PR TITLE
Version 2.1.2

### DIFF
--- a/.version
+++ b/.version
@@ -1,1 +1,1 @@
-{"name":"acuparse","version":"2.1.1","schema":"2.1","updater_url":"https://raw.githubusercontent.com/acuparse/acuparse/master/.version","homepage":"https://www.acuparse.com"}
+{"name":"acuparse","version":"2.1.2","schema":"2.1","updater_url":"https://raw.githubusercontent.com/acuparse/acuparse/master/.version","homepage":"https://www.acuparse.com"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [[2.1.2]](http://www.acuparse.com/releases/v2-1-2/) - 2017-06-16
+### Changed
+- Undoing changes to MyAcurite localtime response. It breaks rainfall data.
+
 ## [[2.1.1]](http://www.acuparse.com/releases/v2-1-1/) - 2017-06-10
 ### Changed
 - Updated wrong installer path in docs/INSTALL.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Acuparse](http://www.acuparse.com) - v2.1.1
+# [Acuparse](http://www.acuparse.com) - v2.1.2
 ## AcuRite®‎ smartHUB and IP Camera Data Processing, Display, and Upload.
 ### See it in action @ [ghwx.ca](http://www.ghwx.ca)
 

--- a/src/pub/admin/install/updates.php
+++ b/src/pub/admin/install/updates.php
@@ -31,4 +31,8 @@ switch ($config->version->app){
         $config->version->app = '2.1.1';
         //$config->version->schema = '2.1';
         $notes = 'Minor changes and bug fixes. See CHANGELOG for details.';
+    case '2.1.1':
+        $config->version->app = '2.1.2';
+        //$config->version->schema = '2.1';
+        $notes = 'See CHANGELOG for details.';
 }

--- a/src/pub/weatherstation/updateweatherstation.php
+++ b/src/pub/weatherstation/updateweatherstation.php
@@ -154,22 +154,17 @@ if ($_GET['id'] === $config->station->hub_mac) {
     if ($config->upload->myacurite->enabled === true) {
         $myacurite = file_get_contents($config->upload->myacurite->url . '/weatherstation/updateweatherstation?' . $myacurite_query);
 
-        // MyAcurite is terrible with timekeeping. Update the response with the current time
-        $myacurite_pattern = '/["localtime":"](\d{2}:\d{2}:\d{2})/';
-        $myacurite_replacement = date('H:i:s');
-        $myacurite_response = preg_replace($myacurite_pattern, $myacurite_replacement, $myacurite);
-
         // Log the raw data
         if ($config->debug->logging === true) {
-            syslog(LOG_DEBUG, "MyAcuRite Query: $myacurite_query | Response: $myacurite | Corrected: $myacurite_response");
+            syslog(LOG_DEBUG, "MyAcuRite Query: $myacurite_query | Response: $myacurite");
         }
 
         // Output the response to the smartHUB
-        echo $myacurite_response;
+        echo $myacurite;
     } // MyAcurite is disabled
     else {
-        // Output a response to the smartHUB
-        echo '{"localtime":"' . date('H:i:s') . '"}';
+        // Output the expected response to the smartHUB
+        echo '{"localtime":"' . date('H:H:H') . '"}';
     }
 
 } // This MAC is not setup


### PR DESCRIPTION
Rainfall data is not clearing correctly. Appears the localtime response
needs to be sent to the hub as H:H:H.

Updating version to 2.1.2. This closes #6.