### PR TITLE
correction to index.php - json_tower

### DIFF
--- a/src/pub/index.php
+++ b/src/pub/index.php
@@ -53,9 +53,9 @@ if (isset($_GET['json'])) {
 
 // Get Tower JSON
 if (isset($_GET['json_tower'])) {
-    $sensor = $_GET['sensor'];
+    $sensor = $_GET['json_tower'];
     require(APP_BASE_PATH . '/fcn/weather/getCurrentTowerData.php');
-    $getData = new getCurrentTowerData(sprintf('%08d', $_GET['sensor']));
+    $getData = new getCurrentTowerData(sprintf('%08d', $sensor));
     echo json_encode($getData->getConditions());
     die();
 }


### PR DESCRIPTION
Correct issue with last release where /json_tower=#### returns 0's for all values.